### PR TITLE
Emit all logs as JSON for logs-ingester compatibility

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
@@ -48,11 +47,13 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
-
 	log := logger.New(serviceName, *debugOn)
+
+	go func() {
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			log.Error("pprof server stopped", slog.Any("error", err))
+		}
+	}()
 
 	// Kubernetes configuration
 	var cfg *rest.Config
@@ -130,7 +131,7 @@ func main() {
 	go func() {
 		atomic.StoreInt32(&healthy, 1)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Error("could not listen on %s - %v", server.Addr, err)
+			log.Error("could not listen", slog.String("addr", server.Addr), slog.Any("error", err))
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
This pull request updates the logging approach in `main.go` to use the structured logger (`slog`) instead of the standard library's `log` package, and improves error reporting for the pprof and main HTTP servers.

Logging improvements:

* Replaced the import of the standard `log` package with `log/slog` and removed all usage of `log.Println`, switching to the structured logger for consistency and better log formatting.
* Updated the pprof server goroutine to log errors using `log.Error` with structured fields, instead of printing them directly.
* Improved error logging for the main HTTP server by using structured logging with address and error fields, instead of formatting them into a string.Route pprof server errors and the server listen error through the slog JSON logger instead of stdlib log/printf-style calls, so every emitted line is a valid JSON object.